### PR TITLE
style:增加了prettier格式化前端代码,并修改了之前代码格式

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+pnpm-lock.yaml

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+/dist/*
+.local
+/node_modules/**
+
+**/*.svg
+**/*.sh
+
+/public/*

--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -1,0 +1,37 @@
+module.exports = {
+  // 一行最多 120 字符
+  printWidth: 120,
+  // 使用 4 个空格缩进
+  tabWidth: 2,
+  // 不使用 tab 缩进，而使用空格
+  useTabs: false,
+  // 行尾需要有分号
+  semi: true,
+  // 使用单引号代替双引号
+  singleQuote: true,
+  // 对象的 key 仅在必要时用引号
+  quoteProps: 'as-needed',
+  // jsx 不使用单引号，而使用双引号
+  jsxSingleQuote: false,
+  // 末尾使用逗号
+  trailingComma: 'all',
+  // 大括号内的首尾需要空格 { foo: bar }
+  bracketSpacing: true,
+  // jsx 标签的反尖括号需要换行
+  jsxBracketSameLine: false,
+  // 箭头函数，只有一个参数的时候，也需要括号
+  arrowParens: 'always',
+  // 每个文件格式化的范围是文件的全部内容
+  rangeStart: 0,
+  rangeEnd: Infinity,
+  // 不需要写文件开头的 @prettier
+  requirePragma: false,
+  // 不需要自动在文件开头插入 @prettier
+  insertPragma: false,
+  // 使用默认的折行标准
+  proseWrap: 'never',
+  // 根据显示样式决定 html 要不要折行
+  htmlWhitespaceSensitivity: 'ignore',
+  // 换行符使用 lf
+  endOfLine: 'auto',
+};

--- a/package.json
+++ b/package.json
@@ -7,12 +7,17 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "tauri": "tauri"
+    "lint:prettier": "prettier --write --log-level=warn \"src/**/*.{js,ts,json,tsx,css,less,scss,vue,html,md}\"",
+    "prettier:comment": "自动格式化当前目录下的所有文件",
+    "prettier": "prettier --write .",
+    "tauri": "tauri",
+    "start": "tauri dev"
   },
   "dependencies": {
     "@tauri-apps/api": "^1.5.1",
     "echarts": "^5.4.3",
     "element-plus": "^2.4.3",
+    "prettier": "^3.1.1",
     "sass": "^1.69.5",
     "sass-loader": "^13.3.2",
     "scss": "^0.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ dependencies:
   element-plus:
     specifier: ^2.4.3
     version: 2.4.3(vue@3.3.11)
+  prettier:
+    specifier: ^3.1.1
+    version: 3.1.1
   sass:
     specifier: ^1.69.5
     version: 1.69.5
@@ -371,6 +374,7 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -380,6 +384,7 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: true
     optional: true
@@ -389,6 +394,7 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -398,6 +404,7 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: true
     optional: true
@@ -1107,6 +1114,12 @@ packages:
       nanoid: 3.3.7
       picocolors: 1.0.0
       source-map-js: 1.0.2
+
+  /prettier@3.1.1:
+    resolution: {integrity: sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dev: false
 
   /punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,10 +2,9 @@
 // This starter template is using Vue 3 <script setup> SFCs
 // Check out https://vuejs.org/api/sfc-script-setup.html#script-setup
 
-import Menu from "./components/menu/index.vue";
-import Info from "./components/info/index.vue"
+import Menu from './components/menu/index.vue';
+import Info from './components/info/index.vue';
 </script>
-
 
 <template>
   <div class="common-layout">
@@ -15,7 +14,7 @@ import Info from "./components/info/index.vue"
         <Info />
       </el-aside>
       <el-main>
-        <el-header >Header</el-header>
+        <el-header>Header</el-header>
         <router-view></router-view>
       </el-main>
     </el-container>
@@ -23,22 +22,22 @@ import Info from "./components/info/index.vue"
 </template>
 
 <style scoped>
-.common-layout{
+.common-layout {
   height: 100%;
 }
-.el-container{
+.el-container {
   height: 100%;
 }
 
 /* .el-aside{
   border-right: solid 1px var(--el-menu-border-color);
 } */
-.el-header{
+.el-header {
   height: 5%;
   margin: 0;
 }
 
-.el-main{
+.el-main {
   padding: 10px;
 }
 </style>

--- a/src/components/info/components/Info.vue
+++ b/src/components/info/components/Info.vue
@@ -1,12 +1,10 @@
 <template>
-    <el-footer>footer</el-footer>
+  <el-footer>footer</el-footer>
 </template>
 
-
 <style scoped>
-.el-footer{
-    border-right: solid 1px var(--el-menu-border-color);
-    height: 10%;
-  }
-  
+.el-footer {
+  border-right: solid 1px var(--el-menu-border-color);
+  height: 10%;
+}
 </style>

--- a/src/components/info/index.vue
+++ b/src/components/info/index.vue
@@ -1,14 +1,14 @@
 <template>
-    <component :is="typeComponentMap[type]" class="Info" />
+  <component :is="typeComponentMap[type]" class="Info" />
 </template>
 <script lang="ts" setup>
 import Info from './components/Info.vue';
 defineOptions({ name: 'Info' });
 defineProps({
-    type: {
-        type: String,
-        default: 'Info',
-    },
+  type: {
+    type: String,
+    default: 'Info',
+  },
 });
 
 const typeComponentMap = { Info };

--- a/src/components/menu/components/Menu.vue
+++ b/src/components/menu/components/Menu.vue
@@ -1,22 +1,16 @@
-<script setup>
-
-
-</script>
+<script setup></script>
 
 <template>
-    <el-menu router>
-      <el-menu-item index="/">Home</el-menu-item>
-      <el-menu-item index="/tools">Tools</el-menu-item>
-      <el-menu-item index="/search">Search</el-menu-item>
-      <!-- 其他菜单项... -->
-    </el-menu>
-    
+  <el-menu router>
+    <el-menu-item index="/">Home</el-menu-item>
+    <el-menu-item index="/tools">Tools</el-menu-item>
+    <el-menu-item index="/search">Search</el-menu-item>
+    <!-- 其他菜单项... -->
+  </el-menu>
 </template>
 
-
 <style scoped>
-.el-menu{
-    height: 90%;
+.el-menu {
+  height: 90%;
 }
-
 </style>

--- a/src/components/menu/index.vue
+++ b/src/components/menu/index.vue
@@ -1,14 +1,14 @@
 <template>
-    <component :is="typeComponentMap[type]" class="Menu" />
+  <component :is="typeComponentMap[type]" class="Menu" />
 </template>
 <script lang="ts" setup>
 import Menu from './components/Menu.vue';
 defineOptions({ name: 'Menu' });
 defineProps({
-    type: {
-        type: String,
-        default: 'Menu',
-    },
+  type: {
+    type: String,
+    default: 'Menu',
+  },
 });
 
 const typeComponentMap = { Menu };

--- a/src/components/sysinfo/CPUInfo.vue
+++ b/src/components/sysinfo/CPUInfo.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
-import { ref, onMounted, onUnmounted, nextTick } from "vue";
-import { invoke } from '@tauri-apps/api'
+import { ref, onMounted, onUnmounted, nextTick } from 'vue';
+import { invoke } from '@tauri-apps/api';
 
 interface TableDataItem {
   Index: string;
@@ -17,16 +17,16 @@ const tableData = ref<TableDataItem[]>([
 ]);
 
 const getProgressStatus = (percentage) => {
-  if (percentage <= 50) return "success";
-  if (percentage > 50 && percentage < 70) return "warning";
-  return "exception";
+  if (percentage <= 50) return 'success';
+  if (percentage > 50 && percentage < 70) return 'warning';
+  return 'exception';
 };
 
-const firstColumnWidth = ref(""); // 存储第一列的宽度
-const secondColumnWidth = ref(""); // 存储第二列的宽度
+const firstColumnWidth = ref(''); // 存储第一列的宽度
+const secondColumnWidth = ref(''); // 存储第二列的宽度
 
 const updateColumnWidths = () => {
-  const tableElement = document.getElementById("CPU-Info"); // 替换为您的表格元素选择器
+  const tableElement = document.getElementById('CPU-Info'); // 替换为您的表格元素选择器
   if (tableElement) {
     const tableWidth = tableElement.clientWidth;
     firstColumnWidth.value = `${(tableWidth - 20) * 0.2}px`; // 30% 的宽度
@@ -35,16 +35,16 @@ const updateColumnWidths = () => {
 };
 
 const fetchCPUInfo = () => {
-  invoke("get_cpu_info")
+  invoke('get_cpu_info')
     .then((dataStr) => {
       const data = JSON.parse(dataStr);
       tableData.value = data.map((item, index) => ({
-        Index: `CPU${index}`, 
-        Useage: Math.floor(item.usage)
+        Index: `CPU${index}`,
+        Useage: Math.floor(item.usage),
       }));
     })
     .catch((error) => {
-      console.error("Error fetching CPU info:", error);
+      console.error('Error fetching CPU info:', error);
     });
 };
 
@@ -53,7 +53,7 @@ let intervalId: number | undefined;
 onMounted(() => {
   updateColumnWidths();
   fetchCPUInfo();
-  window.addEventListener("resize", updateColumnWidths);
+  window.addEventListener('resize', updateColumnWidths);
 
   intervalId = setInterval(() => {
     fetchCPUInfo(); // 定时获取 CPU 信息
@@ -64,7 +64,7 @@ onMounted(() => {
 });
 
 onUnmounted(() => {
-  window.removeEventListener("resize", updateColumnWidths);
+  window.removeEventListener('resize', updateColumnWidths);
   if (intervalId !== undefined) {
     clearInterval(intervalId);
   }

--- a/src/components/sysinfo/DiskInfo.vue
+++ b/src/components/sysinfo/DiskInfo.vue
@@ -8,7 +8,7 @@ const updateColumnWidth = () => {
   const tableElement = document.getElementById('Disk-Info'); // 使用表格的 ID
   if (tableElement) {
     const numberOfColumns = 5; // 列数
-    ColumnWidth.value = `${(tableElement.clientWidth-20) / numberOfColumns}px`;
+    ColumnWidth.value = `${(tableElement.clientWidth - 20) / numberOfColumns}px`;
   }
 };
 
@@ -22,42 +22,45 @@ onUnmounted(() => {
 });
 
 interface TableDataItem {
-    Disk: string;
-    MP: string;
-    Size: Number;
-    Used: Number;
-    Avail: Number;
+  Disk: string;
+  MP: string;
+  Size: Number;
+  Used: Number;
+  Avail: Number;
 }
 
 const tableData = ref<TableDataItem[]>([
-  { Disk: 'sda3', MP: '/', Size: 908, Used: 63, Avail: 844},
-  { Disk: 'sda2', MP: '/boot', Size: 240, Used: 63, Avail: 177},
-  { Disk: 'sda1', MP: '/srv', Size: 908, Used: 63, Avail: 844},
-  { Disk: 'sda0', MP: '/tmp', Size: 240, Used: 63, Avail: 177}
+  { Disk: 'sda3', MP: '/', Size: 908, Used: 63, Avail: 844 },
+  { Disk: 'sda2', MP: '/boot', Size: 240, Used: 63, Avail: 177 },
+  { Disk: 'sda1', MP: '/srv', Size: 908, Used: 63, Avail: 844 },
+  { Disk: 'sda0', MP: '/tmp', Size: 240, Used: 63, Avail: 177 },
 ]);
 
 // 格式化函数
 const format = (row, column, cellValue, index) => {
   return `${cellValue} G`;
 };
-
 </script>
 
-
 <template>
-    <el-table :data="tableData" height="100%" style="width: 100%; font-size: 10px;" label="auto" 
-    :cell-style="{padding:'0px'}" id="Disk-Info">
-      <el-table-column prop="Disk" label="Disk"  :width="ColumnWidth"/>
-      <el-table-column prop="MP" label="MP"  :width="ColumnWidth"/>
-      <el-table-column prop="Size" label="Size"  :width="ColumnWidth" :formatter="format"/>
-      <el-table-column prop="Used" label="Used"  :width="ColumnWidth" :formatter="format"/>
-      <el-table-column prop="Avail" label="Avail"  :width="ColumnWidth" :formatter="format"/>
-      
-    </el-table>
+  <el-table
+    :data="tableData"
+    height="100%"
+    style="width: 100%; font-size: 10px"
+    label="auto"
+    :cell-style="{ padding: '0px' }"
+    id="Disk-Info"
+  >
+    <el-table-column prop="Disk" label="Disk" :width="ColumnWidth" />
+    <el-table-column prop="MP" label="MP" :width="ColumnWidth" />
+    <el-table-column prop="Size" label="Size" :width="ColumnWidth" :formatter="format" />
+    <el-table-column prop="Used" label="Used" :width="ColumnWidth" :formatter="format" />
+    <el-table-column prop="Avail" label="Avail" :width="ColumnWidth" :formatter="format" />
+  </el-table>
 </template>
 
 <style scoped>
-.el-table{
+.el-table {
   padding: 0px 10px;
 }
 </style>

--- a/src/components/sysinfo/IOInfo.vue
+++ b/src/components/sysinfo/IOInfo.vue
@@ -1,28 +1,28 @@
 <script setup>
-import * as echarts from "echarts";
-import { onMounted, onUnmounted } from "vue";
+import * as echarts from 'echarts';
+import { onMounted, onUnmounted } from 'vue';
 
 let myChart = null;
 
 onMounted(() => {
-  const chartDom = document.getElementById("IO-Info");
+  const chartDom = document.getElementById('IO-Info');
   if (chartDom) {
     myChart = echarts.init(chartDom);
     const option = {
       title: {
-        text: "",
+        text: '',
       },
       tooltip: {
-        trigger: "axis",
+        trigger: 'axis',
         axisPointer: {
-          type: "cross",
+          type: 'cross',
           label: {
-            backgroundColor: "#6a7985",
+            backgroundColor: '#6a7985',
           },
         },
       },
       legend: {
-        data: ["Input", "Output"],
+        data: ['Input', 'Output'],
       },
       toolbox: {
         feature: {
@@ -30,44 +30,44 @@ onMounted(() => {
         },
       },
       grid: {
-        left: "3%",
-        right: "4%",
-        bottom: "3%",
+        left: '3%',
+        right: '4%',
+        bottom: '3%',
         containLabel: true,
       },
       xAxis: [
         {
-          type: "category",
+          type: 'category',
           boundaryGap: false,
-          data: ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
+          data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
         },
       ],
       yAxis: [
         {
-          type: "value",
+          type: 'value',
         },
       ],
       series: [
         {
-          name: "Input",
-          type: "line",
-          stack: "Total",
+          name: 'Input',
+          type: 'line',
+          stack: 'Total',
           areaStyle: {},
           emphasis: {
-            focus: "series",
+            focus: 'series',
           },
           data: [120, 132, 101, 134, 90, 230, 210],
         },
         {
-          name: "Output",
-          type: "line",
-          stack: "Total",
+          name: 'Output',
+          type: 'line',
+          stack: 'Total',
           areaStyle: {},
           emphasis: {
-            focus: "series",
+            focus: 'series',
           },
           data: [220, 182, 191, 234, 290, 330, 310],
-        }
+        },
       ],
     };
     myChart.setOption(option);
@@ -79,7 +79,7 @@ onMounted(() => {
     }
   };
 
-  window.addEventListener("resize", resizeChart);
+  window.addEventListener('resize', resizeChart);
 });
 
 onUnmounted(() => {

--- a/src/components/sysinfo/ProcessInfo.vue
+++ b/src/components/sysinfo/ProcessInfo.vue
@@ -8,9 +8,9 @@ const otherColumnWidth = ref('');
 const updateColumnWidth = () => {
   const tableElement = document.getElementById('Process-Info'); // 使用表格的 ID
   if (tableElement) {
-      nameColumnWidth.value = `${(tableElement.clientWidth - 20) * 0.4}px`;
-      otherColumnWidth.value = `${(tableElement.clientWidth - 20) * 0.2}px`;
-    }
+    nameColumnWidth.value = `${(tableElement.clientWidth - 20) * 0.4}px`;
+    otherColumnWidth.value = `${(tableElement.clientWidth - 20) * 0.2}px`;
+  }
 };
 
 onMounted(() => {
@@ -23,23 +23,22 @@ onUnmounted(() => {
 });
 
 interface TableDataItem {
-    PID: string;
-    Name: string;
-    CPU: Number;
-    Memory: Number;
+  PID: string;
+  Name: string;
+  CPU: Number;
+  Memory: Number;
 }
 
 const tableData = ref<TableDataItem[]>([
-  { PID: '0', Name: 'systemd', CPU: 0,Memory: 0.3},
-  { PID: '1', Name: 'bash', CPU: 0,Memory: 1.7},
-  { PID: '631', Name: 'atd', CPU: 0,Memory: 652},
-  { PID: '11306', Name: 'nginx', CPU: 0,Memory: 2.4},
-  { PID: '11306', Name: 'nginx', CPU: 0,Memory: 2.4},
-  { PID: '11306', Name: 'nginx', CPU: 0,Memory: 2.4},
-  { PID: '11306', Name: 'nginx', CPU: 0,Memory: 2.4},
-  { PID: '11306', Name: 'nginx', CPU: 0,Memory: 2.4},
-  { PID: '11306', Name: 'nginx', CPU: 0,Memory: 2.4},
-
+  { PID: '0', Name: 'systemd', CPU: 0, Memory: 0.3 },
+  { PID: '1', Name: 'bash', CPU: 0, Memory: 1.7 },
+  { PID: '631', Name: 'atd', CPU: 0, Memory: 652 },
+  { PID: '11306', Name: 'nginx', CPU: 0, Memory: 2.4 },
+  { PID: '11306', Name: 'nginx', CPU: 0, Memory: 2.4 },
+  { PID: '11306', Name: 'nginx', CPU: 0, Memory: 2.4 },
+  { PID: '11306', Name: 'nginx', CPU: 0, Memory: 2.4 },
+  { PID: '11306', Name: 'nginx', CPU: 0, Memory: 2.4 },
+  { PID: '11306', Name: 'nginx', CPU: 0, Memory: 2.4 },
 ]);
 
 // 格式化函数
@@ -50,23 +49,26 @@ const formatMem = (row, column, cellValue, index) => {
 const formatCpu = (row, column, cellValue, index) => {
   return `${cellValue} %`;
 };
-
 </script>
 
-
 <template>
-    <el-table :data="tableData" height="100%" style="width: 100%; font-size: 10px;" label="auto" 
-    :cell-style="{padding:'0px'}" id="Process-Info">
-      <el-table-column prop="PID" label="PID"  :width="otherColumnWidth"/>
-      <el-table-column prop="Name" label="Name"  :width="nameColumnWidth"/>
-      <el-table-column prop="CPU" label="CPU"  :width="otherColumnWidth" :formatter="formatCpu"/>
-      <el-table-column prop="Memory" label="Memory"   :width="otherColumnWidth" :formatter="formatMem"/>
-      
-    </el-table>
+  <el-table
+    :data="tableData"
+    height="100%"
+    style="width: 100%; font-size: 10px"
+    label="auto"
+    :cell-style="{ padding: '0px' }"
+    id="Process-Info"
+  >
+    <el-table-column prop="PID" label="PID" :width="otherColumnWidth" />
+    <el-table-column prop="Name" label="Name" :width="nameColumnWidth" />
+    <el-table-column prop="CPU" label="CPU" :width="otherColumnWidth" :formatter="formatCpu" />
+    <el-table-column prop="Memory" label="Memory" :width="otherColumnWidth" :formatter="formatMem" />
+  </el-table>
 </template>
 
 <style scoped>
-.el-table{
+.el-table {
   padding: 0px 10px;
 }
 </style>

--- a/src/components/v-charts/components/Pie.vue
+++ b/src/components/v-charts/components/Pie.vue
@@ -1,164 +1,164 @@
 <template>
-    <div :id="id" ref="PieChartRef" :style="{ height: height, width: width }" />
+  <div :id="id" ref="PieChartRef" :style="{ height: height, width: width }" />
 </template>
 <script lang="ts" setup>
-import { onMounted, nextTick, watch, onBeforeUnmount} from 'vue';
+import { onMounted, nextTick, watch, onBeforeUnmount } from 'vue';
 import * as echarts from 'echarts';
 
 const props = defineProps({
-    id: {
-        type: String,
-        default: 'pieChartId',
-    },
-    width: {
-        type: String,
-        default: '100%',
-    },
-    height: {
-        type: String,
-        default: '200px',
-    },
-    option: {
-        type: Object,
-        required: true,
-    }, // option: { title , data }
+  id: {
+    type: String,
+    default: 'pieChartId',
+  },
+  width: {
+    type: String,
+    default: '100%',
+  },
+  height: {
+    type: String,
+    default: '200px',
+  },
+  option: {
+    type: Object,
+    required: true,
+  }, // option: { title , data }
 });
 
 function initChart() {
-    let myChart = echarts?.getInstanceByDom(document.getElementById(props.id) as HTMLElement);
-    if (myChart === null || myChart === undefined) {
-        myChart = echarts.init(document.getElementById(props.id) as HTMLElement);
-    }
-    const theme = 'light';
-    let percentText = String(props.option.data).split('.');
-    const option = {
-        title: [
-            {
-                text: `{a|${percentText[0]}.}{b|${percentText[1] || 0} %}`,
-                textStyle: {
-                    rich: {
-                        a: {
-                            fontSize: '22',
-                        },
-                        b: {
-                            fontSize: '14',
-                            padding: [5, 0, 0, 0],
-                        },
-                    },
+  let myChart = echarts?.getInstanceByDom(document.getElementById(props.id) as HTMLElement);
+  if (myChart === null || myChart === undefined) {
+    myChart = echarts.init(document.getElementById(props.id) as HTMLElement);
+  }
+  const theme = 'light';
+  let percentText = String(props.option.data).split('.');
+  const option = {
+    title: [
+      {
+        text: `{a|${percentText[0]}.}{b|${percentText[1] || 0} %}`,
+        textStyle: {
+          rich: {
+            a: {
+              fontSize: '22',
+            },
+            b: {
+              fontSize: '14',
+              padding: [5, 0, 0, 0],
+            },
+          },
 
-                    color: theme === 'dark' ? '#ffffff' : '#0f0f0f',
-                    lineHeight: 25,
-                    // fontSize: 20,
-                    fontWeight: 500,
-                },
-                left: '49%',
-                top: '32%',
-                subtext: props.option.title,
-                subtextStyle: {
-                    color: theme === 'dark' ? '#BBBFC4' : '#646A73',
-                    fontSize: 13,
-                },
-                textAlign: 'center',
-            },
-        ],
-        polar: {
-            radius: ['71%', '80%'],
-            center: ['50%', '50%'],
+          color: theme === 'dark' ? '#ffffff' : '#0f0f0f',
+          lineHeight: 25,
+          // fontSize: 20,
+          fontWeight: 500,
         },
-        angleAxis: {
-            max: 100,
-            show: false,
+        left: '49%',
+        top: '32%',
+        subtext: props.option.title,
+        subtextStyle: {
+          color: theme === 'dark' ? '#BBBFC4' : '#646A73',
+          fontSize: 13,
         },
-        radiusAxis: {
-            type: 'category',
-            show: true,
-            axisLabel: {
-                show: false,
-            },
-            axisLine: {
-                show: false,
-            },
-            axisTick: {
-                show: false,
-            },
+        textAlign: 'center',
+      },
+    ],
+    polar: {
+      radius: ['71%', '80%'],
+      center: ['50%', '50%'],
+    },
+    angleAxis: {
+      max: 100,
+      show: false,
+    },
+    radiusAxis: {
+      type: 'category',
+      show: true,
+      axisLabel: {
+        show: false,
+      },
+      axisLine: {
+        show: false,
+      },
+      axisTick: {
+        show: false,
+      },
+    },
+    series: [
+      {
+        type: 'bar',
+        roundCap: true,
+        barWidth: 30,
+        showBackground: true,
+        coordinateSystem: 'polar',
+        backgroundStyle: {
+          color: theme === 'dark' ? 'rgba(255, 255, 255, 0.05)' : 'rgba(0, 94, 235, 0.05)',
         },
-        series: [
+        color: [
+          new echarts.graphic.LinearGradient(0, 1, 0, 0, [
             {
-                type: 'bar',
-                roundCap: true,
-                barWidth: 30,
-                showBackground: true,
-                coordinateSystem: 'polar',
-                backgroundStyle: {
-                    color: theme === 'dark' ? 'rgba(255, 255, 255, 0.05)' : 'rgba(0, 94, 235, 0.05)',
-                },
-                color: [
-                    new echarts.graphic.LinearGradient(0, 1, 0, 0, [
-                        {
-                            offset: 0,
-                            color: 'rgba(81, 192, 255, .1)',
-                        },
-                        {
-                            offset: 1,
-                            color: '#4261F6',
-                        },
-                    ]),
-                ],
-                label: {
-                    show: false,
-                },
-                data: [props.option.data],
+              offset: 0,
+              color: 'rgba(81, 192, 255, .1)',
             },
             {
-                type: 'pie',
-                radius: ['0%', '60%'],
-                center: ['50%', '50%'],
-                label: {
-                    show: false,
-                },
-                color: theme === 'dark' ? '#16191D' : '#fff',
-                data: [
-                    {
-                        value: 0,
-                        itemStyle: {
-                            shadowColor: theme === 'dark' ? '#16191D' : 'rgba(0, 94, 235, 0.1)',
-                            shadowBlur: 5,
-                        },
-                    },
-                ],
+              offset: 1,
+              color: '#4261F6',
             },
+          ]),
         ],
-    };
-    // 渲染数据
-    myChart.setOption(option, true);
+        label: {
+          show: false,
+        },
+        data: [props.option.data],
+      },
+      {
+        type: 'pie',
+        radius: ['0%', '60%'],
+        center: ['50%', '50%'],
+        label: {
+          show: false,
+        },
+        color: theme === 'dark' ? '#16191D' : '#fff',
+        data: [
+          {
+            value: 0,
+            itemStyle: {
+              shadowColor: theme === 'dark' ? '#16191D' : 'rgba(0, 94, 235, 0.1)',
+              shadowBlur: 5,
+            },
+          },
+        ],
+      },
+    ],
+  };
+  // 渲染数据
+  myChart.setOption(option, true);
 }
 
 function changeChartSize() {
-    echarts.getInstanceByDom(document.getElementById(props.id) as HTMLElement)?.resize();
+  echarts.getInstanceByDom(document.getElementById(props.id) as HTMLElement)?.resize();
 }
 
 watch(
-    () => props.option,
-    (val) => {
-        if (val) {
-            nextTick(() => {
-                initChart();
-            });
-        }
-    },
-    { deep: true }
+  () => props.option,
+  (val) => {
+    if (val) {
+      nextTick(() => {
+        initChart();
+      });
+    }
+  },
+  { deep: true },
 );
 
 onMounted(() => {
-    nextTick(() => {
-        initChart();
-        window.addEventListener('resize', changeChartSize);
-    });
+  nextTick(() => {
+    initChart();
+    window.addEventListener('resize', changeChartSize);
+  });
 });
 
 onBeforeUnmount(() => {
-    echarts.getInstanceByDom(document.getElementById(props.id) as HTMLElement).dispose();
-    window.removeEventListener('resize', changeChartSize);
+  echarts.getInstanceByDom(document.getElementById(props.id) as HTMLElement).dispose();
+  window.removeEventListener('resize', changeChartSize);
 });
 </script>
 <style lang="scss" scoped></style>

--- a/src/components/v-charts/index.vue
+++ b/src/components/v-charts/index.vue
@@ -1,24 +1,24 @@
 <template>
-    <component :is="typeComponentMap[type]" :height="height" :option="option" :dataZoom="dataZoom" class="v-charts" />
+  <component :is="typeComponentMap[type]" :height="height" :option="option" :dataZoom="dataZoom" class="v-charts" />
 </template>
 <script lang="ts" setup>
 // import line from './components/Line.vue';
 import pie from './components/Pie.vue';
 defineOptions({ name: 'VCharts' });
 defineProps({
-    type: {
-        type: String,
-        default: 'pie',
-    },
-    height: {
-        type: String,
-        default: '200px',
-    },
-    dataZoom: Boolean,
-    option: {
-        type: Object,
-        required: false,
-    }, // { title , xDatas, yDatas, formatStr  }
+  type: {
+    type: String,
+    default: 'pie',
+  },
+  height: {
+    type: String,
+    default: '200px',
+  },
+  dataZoom: Boolean,
+  option: {
+    type: Object,
+    required: false,
+  }, // { title , xDatas, yDatas, formatStr  }
 });
 
 const typeComponentMap = { pie };

--- a/src/main.js
+++ b/src/main.js
@@ -1,12 +1,12 @@
-import { createApp } from "vue";
+import { createApp } from 'vue';
 import ElementPlus from 'element-plus';
-import 'element-plus/dist/index.css'
+import 'element-plus/dist/index.css';
 
-import App from "./App.vue";
-import router from "./router";
-import './styles.css'
+import App from './App.vue';
+import router from './router';
+import './styles.css';
 
 const app = createApp(App);
 app.use(ElementPlus);
 app.use(router);
-app.mount("#app");
+app.mount('#app');

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,17 +1,15 @@
-import { createRouter, createWebHistory } from "vue-router"
-import Home from "../views/Home.vue"
-import Tools from "../views/Tools.vue"
-import Search from "../views/Search.vue"
+import { createRouter, createWebHistory } from 'vue-router';
+import Home from '../views/Home.vue';
+import Tools from '../views/Tools.vue';
+import Search from '../views/Search.vue';
 
-const router = createRouter(
-    {
-        history: createWebHistory(), 
-        routes: [
-            { name:'Home', path: '/', component: Home },
-            { name:'Tools', path: '/tools', component: Tools },
-            { name:'Search', path: '/search', component: Search },
-        ]
-    }
-)
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [
+    { name: 'Home', path: '/', component: Home },
+    { name: 'Tools', path: '/tools', component: Tools },
+    { name: 'Search', path: '/search', component: Search },
+  ],
+});
 
-export default router
+export default router;

--- a/src/styles.css
+++ b/src/styles.css
@@ -14,11 +14,11 @@
   -webkit-text-size-adjust: 100%;
 }
 
-body{
+body {
   margin: 0;
   height: 100vh;
 }
 
-#app{
+#app {
   height: 100%;
 }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,29 +1,29 @@
 <script setup>
-import CPUInfo from "../components/sysinfo/CPUInfo.vue";
-import DiskInfo from "../components/sysinfo/DiskInfo.vue";
-import ProcessInfo from "../components/sysinfo/ProcessInfo.vue";
-import Pie from "../components/v-charts/index.vue";
-import IOInfo from "../components/sysinfo/IOInfo.vue"
-import { ref, onMounted, nextTick } from "vue";
+import CPUInfo from '../components/sysinfo/CPUInfo.vue';
+import DiskInfo from '../components/sysinfo/DiskInfo.vue';
+import ProcessInfo from '../components/sysinfo/ProcessInfo.vue';
+import Pie from '../components/v-charts/index.vue';
+import IOInfo from '../components/sysinfo/IOInfo.vue';
+import { ref, onMounted, nextTick } from 'vue';
 
 const pieWidth = '200px';
 
 const chartsOption = ref({
   cpuChart: {
     title: 'CPU',
-    data: 65.89
+    data: 65.89,
   },
   memoryChart: {
     title: 'Memory',
-    data: 65.89
+    data: 65.89,
   },
   loadChart: {
     title: 'Load',
-    data: 65.89
+    data: 65.89,
   },
   diskChart: {
     title: 'Disk',
-    data: 65.89
+    data: 65.89,
   },
 });
 onMounted(() => {
@@ -40,8 +40,8 @@ onMounted(() => {
 
 <template>
   <el-row :gutter="10">
-    <el-col :span="24"
-      ><div class="grid-content ep-bg-purple">
+    <el-col :span="24">
+      <div class="grid-content ep-bg-purple">
         <el-card class="box-card">
           <div class="flex-pie">
             <Pie id="cpu" :width="pieWidth" :option="chartsOption.cpuChart" />
@@ -54,33 +54,36 @@ onMounted(() => {
     </el-col>
   </el-row>
   <el-row :gutter="5">
-    <el-col :span="8"
-      ><div class="grid-content ep-bg-purple">
+    <el-col :span="8">
+      <div class="grid-content ep-bg-purple">
         <el-card class="box-card">
           <CPUInfo />
-        </el-card></div
-    ></el-col>
-    <el-col :span="8"
-      ><div class="grid-content ep-bg-purple">
+        </el-card>
+      </div>
+    </el-col>
+    <el-col :span="8">
+      <div class="grid-content ep-bg-purple">
         <el-card class="box-card">
           <DiskInfo />
-        </el-card></div
-    ></el-col>
-    <el-col :span="8"
-      ><div class="grid-content ep-bg-purple">
+        </el-card>
+      </div>
+    </el-col>
+    <el-col :span="8">
+      <div class="grid-content ep-bg-purple">
         <el-card class="box-card">
           <IOInfo />
         </el-card>
-      </div></el-col
-    >
+      </div>
+    </el-col>
   </el-row>
   <el-row :gutter="10">
-    <el-col :span="24"
-      ><div class="grid-content ep-bg-purple">
+    <el-col :span="24">
+      <div class="grid-content ep-bg-purple">
         <el-card class="box-card">
           <ProcessInfo />
-        </el-card></div
-    ></el-col>
+        </el-card>
+      </div>
+    </el-col>
   </el-row>
 </template>
 
@@ -93,21 +96,21 @@ onMounted(() => {
     .grid-content {
       border: none;
       height: 100%;
-        .box-card {
-          width: 100%;
-          height: 100%;
-          /* background-color: lightgreen; */
-        }
-        .flex-pie {
-          display: flex;
-          flex-direction: row;
-          justify-content: flex-start;
-          flex-wrap: nowrap;
-        }
-        :deep(.el-card__body) {
-          padding: 0px !important;
-          height: 100%;
-        }
+      .box-card {
+        width: 100%;
+        height: 100%;
+        /* background-color: lightgreen; */
+      }
+      .flex-pie {
+        display: flex;
+        flex-direction: row;
+        justify-content: flex-start;
+        flex-wrap: nowrap;
+      }
+      :deep(.el-card__body) {
+        padding: 0px !important;
+        height: 100%;
+      }
     }
   }
 }

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -1,9 +1,8 @@
 <template>
-    <el-input v-model="input" placeholder="Please input" />
-  </template>
-  
-  <script lang="ts" setup>
-  import { ref } from 'vue'
-  const input = ref('')
-  </script>
-  
+  <el-input v-model="input" placeholder="Please input" />
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue';
+const input = ref('');
+</script>

--- a/src/views/Tools.vue
+++ b/src/views/Tools.vue
@@ -1,27 +1,26 @@
 <template>
-    <el-tabs v-model="activeName" class="demo-tabs" @tab-click="handleClick">
-      <el-tab-pane label="User" name="first">User</el-tab-pane>
-      <el-tab-pane label="Config" name="second">Config</el-tab-pane>
-      <el-tab-pane label="Role" name="third">Role</el-tab-pane>
-      <el-tab-pane label="Task" name="fourth">Task</el-tab-pane>
-    </el-tabs>
-  </template>
-  <script lang="ts" setup>
-  import { ref } from 'vue'
-  import type { TabsPaneContext } from 'element-plus'
-  
-  const activeName = ref('first')
-  
-  const handleClick = (tab: TabsPaneContext, event: Event) => {
-    console.log(tab, event)
-  }
-  </script>
-  <style>
-  .demo-tabs > .el-tabs__content {
-    padding: 32px;
-    color: #6b778c;
-    font-size: 32px;
-    font-weight: 600;
-  }
-  </style>
-  
+  <el-tabs v-model="activeName" class="demo-tabs" @tab-click="handleClick">
+    <el-tab-pane label="User" name="first">User</el-tab-pane>
+    <el-tab-pane label="Config" name="second">Config</el-tab-pane>
+    <el-tab-pane label="Role" name="third">Role</el-tab-pane>
+    <el-tab-pane label="Task" name="fourth">Task</el-tab-pane>
+  </el-tabs>
+</template>
+<script lang="ts" setup>
+import { ref } from 'vue';
+import type { TabsPaneContext } from 'element-plus';
+
+const activeName = ref('first');
+
+const handleClick = (tab: TabsPaneContext, event: Event) => {
+  console.log(tab, event);
+};
+</script>
+<style>
+.demo-tabs > .el-tabs__content {
+  padding: 32px;
+  color: #6b778c;
+  font-size: 32px;
+  font-weight: 600;
+}
+</style>


### PR DESCRIPTION
### 根据以下操作简单配置本地prettier,简单约束代码格式.
1. 安装 Prettier 插件：
    打开 VS Code，进入 Extensions（Extensions 视图的图标是方块和小拼图图标，也可以通过快捷键 Ctrl+Shift+X 打开）。在搜索框中输入 "Prettier"，找到 Prettier - Code formatter 插件，并点击安装。

2. 配置 VS Code 自动保存时格式化：
打开 VS Code 设置（Ctrl+, 或者通过 File -> Preferences -> Settings），搜索 "Format On Save" 并确保其为选中状态。这将在你保存文件时自动触发 Prettier 格式化。

3. 配置 .prettierrc 文件：
确保你的项目根目录下有一个 .prettierrc（或者 .prettierrc.js 或其他格式）文件，其中包含你希望 Prettier 遵循的格式规则。

4. 配置 VS Code 自动检测 Prettier：
在 VS Code 设置中搜索 "Prettier: Require Config"，并确保其为选中状态。这样会在你打开项目时自动检测项目中是否存在 Prettier 配置文件。